### PR TITLE
CDS-1532 / MJM-18 : amended closenotes/fn rule to check for specific-…

### DIFF
--- a/distro/Rules/Nature-NLM.sch
+++ b/distro/Rules/Nature-NLM.sch
@@ -2863,7 +2863,7 @@ Use the <let> element to define the attribute if necessary.
   </pattern>
    <pattern><!--closenotes - fn-type="other"-->
       <rule context="back/fn-group[@content-type='closenotes']/fn" role="error">
-         <assert id="back-fn6a" test="@fn-type='other'">"fn" within closenotes should have attribute fn-type="other".</assert>
+         <assert id="back-fn6a" test="@specific-use='print-only'">"fn" within closenotes should have attribute specific-use="print-only".</assert>
       </rule>
   </pattern>
    <pattern><!--closenotes - id attribute not necessary-->


### PR DESCRIPTION
…use="print-only" instead of fn-type="other".